### PR TITLE
Update README to reflect pushkind-todo purpose

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# pushkind-template
+# pushkind-todo
 
-`pushkind-template` is a template repository for building Pushkind web services powered by Rust, Actix Web, Diesel, and Tera on top of Bootstrap 5.3 for the frontend.
+`pushkind-todo` is a Pushkind web service for creating, assigning, and tracking tasks, powered by Rust, Actix Web, Diesel, and Tera on top of Bootstrap 5.3 for the frontend.
 
 ## Features
 


### PR DESCRIPTION
## Summary
- rename the README title to pushkind-todo
- describe the service as focused on creating, assigning, and tracking tasks

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd42bb0770832a8e76c4eb865b8fa3