### PR TITLE
Document user domain models

### DIFF
--- a/src/domain/user.rs
+++ b/src/domain/user.rs
@@ -1,18 +1,27 @@
 use pushkind_common::domain::auth::AuthenticatedUser;
 use serde::{Deserialize, Serialize};
 
+/// Domain representation of a user belonging to a specific hub.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Default)]
 pub struct User {
+    /// Unique identifier for the user.
     pub id: i32,
+    /// Hub the user is associated with.
     pub hub_id: i32,
+    /// Display name of the user.
     pub name: String,
+    /// Primary email address used for authentication and notifications.
     pub email: String,
 }
 
+/// Parameters required to create a new user.
 #[derive(Clone, Debug, Deserialize)]
 pub struct NewUser {
+    /// Hub that should own the new user.
     pub hub_id: i32,
+    /// Display name for the new user.
     pub name: String,
+    /// Email address used to identify and contact the user.
     pub email: String,
 }
 
@@ -27,8 +36,10 @@ impl NewUser {
     }
 }
 
+/// Payload for updating mutable user fields.
 #[derive(Clone, Debug, Deserialize)]
 pub struct UpdateUser {
+    /// Updated display name for the user.
     pub name: String,
 }
 


### PR DESCRIPTION
## Summary
- add rustdoc descriptions to the user domain structs and their fields for consistency with other modules

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68e3c55a41d4832aa11a0d7bb9dcd111